### PR TITLE
Corrected username in healthcheck

### DIFF
--- a/roles/mastodon/templates/docker-compose.yml.j2
+++ b/roles/mastodon/templates/docker-compose.yml.j2
@@ -12,7 +12,7 @@ services:
     networks:
       - internal_network
     healthcheck:
-      test: ['CMD', 'pg_isready', '-U', 'postgres']
+      test: ['CMD', 'pg_isready', '-U', 'mastodon']
     volumes:
       - ./postgres14:/var/lib/postgresql/data
     # - ./postgres14:/var/lib/postgresql/14/main/data


### PR DESCRIPTION
Healthcheck in docker-compose uses user 'postgres' but this user is never created. The user created for the database is 'mastodon'.  This results in a failed healthcheck.