### PR TITLE
use `latest` and allow for updates

### DIFF
--- a/roles/mastodon/templates/docker-compose.yml.j2
+++ b/roles/mastodon/templates/docker-compose.yml.j2
@@ -29,7 +29,7 @@ services:
 
   web:
 #   build: .
-    image: tootsuite/mastodon:{{ mastodonlatest }}
+    image: tootsuite/mastodon:latest
     restart: always
     env_file: .env.production
     command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000"
@@ -50,7 +50,7 @@ services:
 
   streaming:
 #   build: .
-    image: tootsuite/mastodon:{{ mastodonlatest }}
+    image: tootsuite/mastodon:latest
     restart: always
     env_file: .env.production
     command: node ./streaming
@@ -68,7 +68,7 @@ services:
 
   sidekiq:
 #   build: .
-    image: tootsuite/mastodon:{{ mastodonlatest }}
+    image: tootsuite/mastodon:latest
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq

--- a/roles/mastodon/templates/docker-compose.yml.j2
+++ b/roles/mastodon/templates/docker-compose.yml.j2
@@ -29,7 +29,7 @@ services:
 
   web:
 #   build: .
-    image: tootsuite/mastodon:latest
+    image: tootsuite/mastodon:{{ mastodonlatest }}
     restart: always
     env_file: .env.production
     command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000"
@@ -50,7 +50,7 @@ services:
 
   streaming:
 #   build: .
-    image: tootsuite/mastodon:latest
+    image: tootsuite/mastodon:{{ mastodonlatest }}
     restart: always
     env_file: .env.production
     command: node ./streaming
@@ -68,7 +68,7 @@ services:
 
   sidekiq:
 #   build: .
-    image: tootsuite/mastodon:latest
+    image: tootsuite/mastodon:{{ mastodonlatest }}
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq

--- a/roles/mastodon/templates/docker-compose.yml.j2
+++ b/roles/mastodon/templates/docker-compose.yml.j2
@@ -83,6 +83,12 @@ services:
     healthcheck:
       test: ['CMD-SHELL', "ps aux | grep '[s]idekiq\ 6' || false"]
 
+  watchtower:
+    image: containrrr/watchtower
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
 networks:
   external_network:
   internal_network:


### PR DESCRIPTION
- Uses `latest` branch instead of a specific version for mastodon
- Adds watchtower to keep mastodon up-to-date